### PR TITLE
Remove unecessary call to list built-in

### DIFF
--- a/workshops/2017-fall/alphabetical/alphabetical.py
+++ b/workshops/2017-fall/alphabetical/alphabetical.py
@@ -5,7 +5,7 @@ def naive_is_alphabetical(word):
         If the two are equal, then the word
         was already in order.
     """
-    return word == ''.join(sorted(list(word)))
+    return word == ''.join(sorted(word))
 
 
 def is_alphabetical(word):


### PR DESCRIPTION
Sorted can take any iterable whose elements
provide an ordering, but still returns a list.

My apologies to Tim Hung for the misinformation.
Pls forgive. See [here](https://docs.python.org/3/glossary.html?highlight=eafp#term-eafp)